### PR TITLE
Add support for signatures for let, let!, subject blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 
 More advanced RSpec usage patterns require the use of the DSL compiler as well as manually-inserted type hints. These usage patterns include:
 
-- `let`s.
+- `let`, `let!`, and `subject`.
 - Methods defined inside spec blocks.
 - `include`s inside spec blocks.
 
@@ -58,7 +58,7 @@ For example, consider this code, which fails typechecking:
 require "rspec"
 
 RSpec.describe "bar" do
-  let(:number) { 100}
+  let(:number) { 100 }
 
   specify "let works" do
     expect(number).to eq(100)
@@ -90,7 +90,7 @@ RSpec.describe "bar" do
   # !!! Manually insert type hint !!!
   T.bind(self, T.class_of(RSpec::ExampleGroups::Bar))
 
-  let(:number) { 100}
+  let(:number) { 100 }
 
   specify "let works" do
     expect(number).to eq(100) # typecheck passes!
@@ -158,7 +158,7 @@ RSpec.describe "methods test" do
 end
 ```
 
-Luckily, there is a workaround. Create a file _somewhere_ in your project, containing the following code, to fool the Sorbet typechecker into accepting the `sig` call:
+Luckily, there is a workaround. Create a file _somewhere_ in your project, containing the following code, to fool the Sorbet typechecker into accepting the `sig`s (or the `rsig`s described further in the document):
 
 ```ruby
 # typed: strict
@@ -169,7 +169,66 @@ if false # rubocop:disable Lint/LiteralAsCondition
   T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
   def sig(&block)
   end
+
+  T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
+  def rsig(&block)
+  end
 end
 ```
 
 This file can live anywhere in your project structure as long as the Sorbet typechecker can find it. The file does not have to be `require`d by your specs.
+
+### Typed let declarations
+
+Even though we made Sorbet aware of the methods defined by the `let` blocks, the return type of those methods by default is `T.untyped`. If we were to try adding a `sig`, Sorbet's static analyzer will report this as an error:
+
+```ruby
+  sig { returns(Integer) }
+  let(:claim_value) { 100 }
+
+  def create_car
+    Car.new
+  # ^^^^^^^~~~ typecheck error:
+  # Expected `Integer` but found `Car` for method result type
+  end
+
+  sig { returns(Integer) }
+# ^^^^^^^^^^^^^^^^^^^^^^^^~~~ typecheck error:
+# Unused type annotation. No method def before next annotation
+  let(:claim_value) { 100 }
+
+  sig { returns(String) }
+  def some_value
+    "42"
+  end
+```
+
+Despite these errors, the signature is in fact perfectly valid at runtime. If a statement containing a signature declaration is executed, sorbet will bind that declaration to either the next method defined with `def`, or the next time `define_method` is executed. If a second signature declaration is encountered before either of these occurs, an error will be raised at runtime. A `let`, `let!`, or `subject` declaration will immediately define a method dynamically. Since there is no real value in having the above safety mechanism in the context of our tests, we can safely remove it.
+
+While clumsy, one way to do this is by using `send` to declare the `sig` dynamically.
+
+```ruby
+  send(:sig) { T.cast(self, T::Private::Methods::DeclBuilder).returns(Integer) }
+  let(:number) { 100 } # no error!
+```
+
+However, that's a bit verbose. Perhaps a better workaround is the use of `rsig`, which is just a tiny wrapper around `sig`, and provided by this gem.
+
+```ruby
+# typed: strict
+require "rspec"
+require "sorbet-rspec"
+
+RSpec.describe "bar" do
+  extend SorbetRspec::Sig # Extending this also extends T::Sig, does not need to be extended again in sub-contexts
+
+  rsig { returns(Integer) }
+  let(:number) { 100 }
+
+  specify "let works" do
+    expect(number).to eq(100) # typecheck passes!
+  end
+end
+```
+
+As with the other changes we made above, it is required to run the dsl compiler (`bin/tapioca dsl`) after adding, removing, or updating these signatures.

--- a/lib/sorbet-rspec.rb
+++ b/lib/sorbet-rspec.rb
@@ -1,0 +1,2 @@
+require "sorbet-runtime"
+require "sorbet-rspec/sig"

--- a/lib/sorbet-rspec/sig.rb
+++ b/lib/sorbet-rspec/sig.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+module SorbetRspec
+  module Sig
+    include Kernel
+
+    def self.extended(sub)
+      super
+      sub.extend(T::Sig)
+    end
+
+    T::Sig::WithoutRuntime.sig { params(decl: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
+    def rsig(&decl)
+      # It would be better if we could simply use the name "sig", but Sorbet falsely reports that as an overload
+      send(:sig, &decl)
+    end
+  end
+end

--- a/sorbet/rbi/dsl/r_spec/example_groups/car.rbi
+++ b/sorbet/rbi/dsl/r_spec/example_groups/car.rbi
@@ -33,6 +33,6 @@ class RSpec::ExampleGroups::Car < RSpec::Core::ExampleGroup
 end
 
 module RSpec::ExampleGroups::Car::LetDefinitions
-  sig { returns(T.untyped) }
+  sig { returns(::Integer) }
   def claim_value; end
 end

--- a/sorbet/rbi/dsl/r_spec/example_groups/car/sub_context.rbi
+++ b/sorbet/rbi/dsl/r_spec/example_groups/car/sub_context.rbi
@@ -43,6 +43,6 @@ class RSpec::ExampleGroups::Car::SubContext < RSpec::ExampleGroups::Car
 end
 
 module RSpec::ExampleGroups::Car::SubContext::LetDefinitions
-  sig { returns(T.untyped) }
+  sig { returns(::Integer) }
   def local_number; end
 end

--- a/spec/typecheck_spec.rb
+++ b/spec/typecheck_spec.rb
@@ -4,9 +4,9 @@
 # This test doesn't actually do anything useful. It only
 # serves to test whether there are typechecking errors.
 
-require "sorbet-runtime"
 require "rspec"
 require "rspec/sorbet"
+require "sorbet-rspec"
 
 RSpec::Sorbet.allow_doubles!
 
@@ -54,12 +54,17 @@ if false # rubocop:disable Lint/LiteralAsCondition
   T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
   def sig(&block)
   end
+
+  T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
+  def rsig(&block)
+  end
 end
 
 RSpec.describe Car do
   T.bind(self, T.class_of(RSpec::ExampleGroups::Car))
-  extend T::Sig
+  extend SorbetRspec::Sig
 
+  rsig { returns(Integer) }
   let(:claim_value) { 100 }
 
   sig { returns(Car) }
@@ -94,6 +99,7 @@ RSpec.describe Car do
   context "sub-context" do
     T.bind(self, T.class_of(RSpec::ExampleGroups::Car::SubContext))
 
+    rsig { returns(Integer) }
     let(:local_number) { 200 }
 
     sig { returns(Integer) }
@@ -107,6 +113,7 @@ RSpec.describe Car do
     end
 
     it "can call local lets and methods" do
+      T.assert_type!(local_number, Integer)
       expect(local_number).to eq(200)
       expect(local_number2).to eq(202)
     end


### PR DESCRIPTION
https://github.com/FooBarWidget/sorbet-rspec/pull/5 should also be merged in order for this to work with let! and subject, since this branch excludes the fixes from the other PR to include let! and subject
