### PR TITLE
Update CI check to use tapioca dsl --verify

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,8 @@ jobs:
       - name: Check code formatting with Standard Ruby
         run: bundle exec standardrb 'lib/**/*.rb' 'spec/**/*.rb'
 
-      - name: Test DSL compiler
-        run: |
-          rm -rf sorbet/rbi/dsl
-          ./bin/tapioca dsl
-          if ! git diff --exit-code; then
-            echo "The DSL RBIs for RSpec tests are out of date. Please re-run './bin/tapioca dsl'"
-            exit 1
-          fi
+      - name: Verify DSL compiler
+        run: bundle exec bin/tapioca dsl --verify
 
       - name: Typecheck with Sorbet
         run: bundle exec srb tc


### PR DESCRIPTION
There's a simpler way to do the CI check in this step. It will return a non-successful exit code if the dsl rbi is not in sync. 

Example output:
```
Loading DSL extension classes... Done
Loading Rails application... Done
Loading DSL compiler classes... Done
Checking for out-of-date RBIs...


RBI files are out-of-date. In your development environment, please run:
  `bin/tapioca dsl`
Once it is complete, be sure to commit and push any changes
If you don't observe any changes after running the command locally, ensure your database is in a good
state e.g. run `bin/rails db:reset`

Reason:
  File(s) changed:
  - sorbet/rbi/dsl/r_spec/example_groups/car.rbi
  ```